### PR TITLE
Fix Mau-Mau penalty logic

### DIFF
--- a/src/cards/maumau/model/ActionHandler.java
+++ b/src/cards/maumau/model/ActionHandler.java
@@ -77,6 +77,10 @@ class ActionHandler {
 
         current.playCard(c);
 
+        // if the player did not announce "Mau" before playing the last card
+        if (current.getCards().isEmpty() && !game.getPlayerHandler().didCallMau(current))
+            current.drawCards(1);
+
         if (chosenSuit != null && c.suit() == chosenSuit)
             chosenSuit = null;
 

--- a/src/cards/maumau/model/PlayerHandler.java
+++ b/src/cards/maumau/model/PlayerHandler.java
@@ -140,6 +140,14 @@ class PlayerHandler {
     }
 
     /**
+     * Returns {@code true} if the given player has called "Mau" and is
+     * therefore allowed to finish the game with an empty hand.
+     */
+    boolean didCallMau(Player p) {
+        return state instanceof MauState && remember == p;
+    }
+
+    /**
      * Adds a player to the game.
      *
      * @param player The player to add.


### PR DESCRIPTION
## Summary
- add `PlayerHandler.didCallMau` helper to check if a player announced *Mau*
- penalize players who play their last card without announcing *Mau*

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*
- `gradle test` *(output: `Starting a Gradle Daemon`)*
- `javac $(find src -name '*.java') $(find test -name '*.java')` *(fails: `package org.junit does not exist`)*

------
https://chatgpt.com/codex/tasks/task_e_68437c6922a08322952827fccd754f77