### PR TITLE
Fix Mau-Mau penalty logic

### DIFF
--- a/src/cards/maumau/model/ActionHandler.java
+++ b/src/cards/maumau/model/ActionHandler.java
@@ -77,6 +77,12 @@ class ActionHandler {
 
         current.playCard(c);
 
+        // remember to penalize players who forget to announce "Mau" when they
+        // are left with only one card in hand
+        if (current.getCards().size() == 1 && !game.getPlayerHandler().didCallMau(current)) {
+            game.getPlayerHandler().flagMissedMau(current);
+        }
+
         if (chosenSuit != null && c.suit() == chosenSuit)
             chosenSuit = null;
 

--- a/src/cards/maumau/model/PlayerHandler.java
+++ b/src/cards/maumau/model/PlayerHandler.java
@@ -12,6 +12,7 @@ class PlayerHandler {
     private final List<Player> players = new LinkedList<>();
     private final List<Player> ranking = new ArrayList<>();
     private Player remember;
+    private Player penalized;
     private PlayerHandlerState state = new DefaultState();
 
     /** State pattern interface for the handler. */
@@ -99,6 +100,10 @@ class PlayerHandler {
     void nextTurn(int n) {
         //TODO implement
         state.nextTurn(n);
+        if (penalized != null && penalized == getCurrentPlayer()) {
+            penalized.drawCards(1);
+            penalized = null;
+        }
     }
 
     /**
@@ -140,6 +145,22 @@ class PlayerHandler {
     }
 
     /**
+     * Returns {@code true} if the given player has called "Mau" and is
+     * therefore allowed to finish the game with an empty hand.
+     */
+    boolean didCallMau(Player p) {
+        return state instanceof MauState && remember == p;
+    }
+
+    /**
+     * Marks a player who failed to announce "Mau" so that they draw an
+     * additional penalty card at the start of their next turn.
+     */
+    void flagMissedMau(Player p) {
+        this.penalized = p;
+    }
+
+    /**
      * Adds a player to the game.
      *
      * @param player The player to add.
@@ -177,6 +198,9 @@ class PlayerHandler {
         //TODO implement
         players.remove(p);
         ranking.add(p);
+        if (penalized == p) {
+            penalized = null;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary
- add delayed penalty for not calling Mau when a player has one card
- track pending penalty in `PlayerHandler`
- apply penalty at the start of the player's next turn

## Testing
- `mvn -q test` *(fails: `mvn: command not found`)*
- `gradle test` *(fails: `Directory '/workspace/KVA' does not contain a Gradle build`)*
- `javac $(find src -name '*.java') $(find test -name '*.java')` *(fails: `package org.junit does not exist`)*

------
https://chatgpt.com/codex/tasks/task_e_68437c6922a08322952827fccd754f77